### PR TITLE
Update license range to 2016-2019

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2016 - 2018 Giant Swarm GmbH
+   Copyright 2016 - 2019 Giant Swarm GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I'm confused about what year we should put in our `LICENSE` files. From the repo here looks like it should be.

`Copyright 2016 - 2019 Giant Swarm GmbH`

I'd like to get this sorted and then do a #dev-news post.
