### PR TITLE
move badges on top of the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# PROJECT
-
 [![Build Status](https://api.travis-ci.org/giantswarm/example-opensource-repo.svg)](https://travis-ci.org/giantswarm/example-opensource-repo) [![Go Report Card](https://goreportcard.com/badge/github.com/giantswarm/example-opensource-repo)](https://goreportcard.com/report/github.com/giantswarm/example-opensource-repo) [![](https://godoc.org/github.com/giantswarm/example-opensource-repo?status.svg)](http://godoc.org/github.com/giantswarm/example-opensource-repo) [![](https://img.shields.io/docker/pulls/giantswarm/example-opensource-repo.svg)](http://hub.docker.com/giantswarm/example-opensource-repo) [![IRC Channel](https://img.shields.io/badge/irc-%23giantswarm-blue.svg)](https://kiwiirc.com/client/irc.freenode.net/#giantswarm)
+
+# PROJECT
 
 {LOGO - if available}
 


### PR DESCRIPTION
Most of our repositories usually have the badges placed at the very top of the README.md file even before the project name.

Aligning with the majority here and moving badges to the top.